### PR TITLE
Make package naming unified

### DIFF
--- a/example/http2/README.md
+++ b/example/http2/README.md
@@ -86,7 +86,7 @@ func DefaultLogRowHandle(value *freedom.LogRow) bool {
 
 #### 依赖倒置
 ``` go
-package repositorys
+package repository
 //声明接口
 type GoodsInterface interface {
 	GetGoods(goodsID int) vo.GoodsModel
@@ -109,7 +109,7 @@ func init() {
 // ShopService .
 type ShopService struct {
 	Worker freedom.Worker
-	Goods  repositorys.GoodsInterface //注入接口对象
+	Goods  repository.GoodsInterface //注入接口对象
 }
 
 func (s *ShopService) Shopping(goodsID int) string {

--- a/example/http2/adapter/controller/goods.go
+++ b/example/http2/adapter/controller/goods.go
@@ -1,4 +1,4 @@
-package controllers
+package controller
 
 import (
 	"github.com/8treenet/freedom"

--- a/example/http2/adapter/controller/shop.go
+++ b/example/http2/adapter/controller/shop.go
@@ -1,4 +1,4 @@
-package controllers
+package controller
 
 import (
 	"github.com/8treenet/freedom"

--- a/example/http2/adapter/repository/goods.go
+++ b/example/http2/adapter/repository/goods.go
@@ -1,4 +1,4 @@
-package repositorys
+package repository
 
 import (
 	"strconv"

--- a/example/http2/adapter/repository/interface.go
+++ b/example/http2/adapter/repository/interface.go
@@ -1,4 +1,4 @@
-package repositorys
+package repository
 
 import "github.com/8treenet/freedom/example/http2/domain/vo"
 

--- a/example/http2/domain/shop.go
+++ b/example/http2/domain/shop.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/8treenet/freedom"
-	"github.com/8treenet/freedom/example/http2/adapter/repositorys"
+	"github.com/8treenet/freedom/example/http2/adapter/repository"
 )
 
 func init() {
@@ -22,7 +22,7 @@ func init() {
 // ShopService .
 type ShopService struct {
 	Worker freedom.Worker
-	Goods  repositorys.GoodsInterface
+	Goods  repository.GoodsInterface
 }
 
 // Shopping implment Shopping interface

--- a/example/http2/server/main.go
+++ b/example/http2/server/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/8treenet/freedom"
-	_ "github.com/8treenet/freedom/example/http2/adapter/controllers"
+	_ "github.com/8treenet/freedom/example/http2/adapter/controller"
 	"github.com/8treenet/freedom/example/http2/server/conf"
 	"github.com/8treenet/freedom/infra/requests"
 	"github.com/8treenet/freedom/middleware"

--- a/example/infra-example/adapter/controller/goods.go
+++ b/example/infra-example/adapter/controller/goods.go
@@ -1,4 +1,4 @@
-package controllers
+package controller
 
 import (
 	"github.com/8treenet/freedom/example/infra-example/domain"

--- a/example/infra-example/adapter/controller/order.go
+++ b/example/infra-example/adapter/controller/order.go
@@ -1,4 +1,4 @@
-package controllers
+package controller
 
 import (
 	"github.com/8treenet/freedom"

--- a/example/infra-example/adapter/controller/shop.go
+++ b/example/infra-example/adapter/controller/shop.go
@@ -1,4 +1,4 @@
-package controllers
+package controller
 
 import (
 	"github.com/8treenet/freedom"

--- a/example/infra-example/server/main.go
+++ b/example/infra-example/server/main.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/8treenet/freedom"
-	_ "github.com/8treenet/freedom/example/infra-example/adapter/controllers"
+	_ "github.com/8treenet/freedom/example/infra-example/adapter/controller"
 	_ "github.com/8treenet/freedom/example/infra-example/adapter/repository"
 	"github.com/8treenet/freedom/example/infra-example/server/conf"
 	"github.com/8treenet/freedom/infra/kafka"


### PR DESCRIPTION
Make package naming unified: change 'repositorys' to 'repository', 'controllers' to 'controller'. Tested by compile and run example/http2 and example/infra-example.